### PR TITLE
Add 'dicpath' argument in __init__ function of MeCab like tokenizer of konlpy

### DIFF
--- a/mecab/mecab.py
+++ b/mecab/mecab.py
@@ -44,8 +44,13 @@ class MeCabError(Exception):
 
 
 class MeCab:  # APIs are inspried by KoNLPy
-    def __init__(self):
-        self.tagger = _mecab.Tagger('')
+    def __init__(self, dicpath=''):
+        argument = ''
+
+        if dicpath != '':
+            argument = '-d %s' % dicpath
+
+        self.tagger = _mecab.Tagger(argument)
 
     def parse(self, sentence):
         lattice = _create_lattice(sentence)


### PR DESCRIPTION
Add 'dicpath' argument for using another dictionary data.

I reference https://github.com/konlpy/konlpy/blob/master/konlpy/tag/_mecab.py#L71 but it need default absolute path so I also fixed to remove it. https://github.com/konlpy/konlpy/pull/338