### PR TITLE
Add missing prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ A python binding for mecab-ko
 
 ## Prerequisites
 - python3-dev
+- wget
+prerequisites can be installed by the following:
+```
+python3 -m pip install python-dev-tools # pip3 install python-dev-tools
+apt-get install wget # or brew install wget on macOS
+```
 
 ## Installation
 Using `pip`:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A python binding for mecab-ko
 ## Prerequisites
 - python3-dev
 - wget
+
 prerequisites can be installed by the following:
 ```
 python3 -m pip install python-dev-tools # pip3 install python-dev-tools


### PR DESCRIPTION
As I was using this module, I found out that the reason why it sometimes failed to install was because I didn't have `wget` preinstalled. After installing wget, it installed well. So maybe informing other users struggling for install may help!