### PR TITLE
[fix/#9] Fix to setup failed when mecab already installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools.command.build_ext import build_ext
 
 # Based on https://github.com/pybind/python_example
 
-mecab_config_path = os.path.join(sys.prefix, 'bin', 'mecab-config')
+os.environ["PATH"] = os.environ["PATH"] + os.pathsep + os.path.join(sys.prefix, 'bin')
 
 class BuildExtensionCommand(build_ext):
 
@@ -113,13 +113,13 @@ def get_pybind_include(user=False):
 @lazy
 def get_mecab_include_directory():
     return subprocess.check_output([
-        mecab_config_path, '--inc-dir']).decode('utf-8').strip()
+        'mecab-config', '--inc-dir']).decode('utf-8').strip()
 
 
 @lazy
 def get_mecab_library_directory():
     return subprocess.check_output([
-        mecab_config_path, '--libs-only-L']).decode('utf-8').strip()
+        'mecab-config', '--libs-only-L']).decode('utf-8').strip()
 
 
 with open('README.md', 'r', encoding='utf-8') as input_file:


### PR DESCRIPTION
When `mecab` was already installed, setup failed because `mecab-config` wan't exist in bin folder of venv.

So, I changed to use `PATH` environment instead of to use absolute path of `mecab-config`.